### PR TITLE
use subdirectory as root for nginx example

### DIFF
--- a/examples/nginx.nix
+++ b/examples/nginx.nix
@@ -8,7 +8,7 @@
     virtualHosts."main" = {
       default = true;
       locations."/" = {
-        root = ./.;
+        root = ./website;
       };
     };
   };

--- a/module-system/nix-modules.md
+++ b/module-system/nix-modules.md
@@ -274,7 +274,7 @@ Remember to use the module search if you get stuck!
     virtualHosts."main" = {
       default = true;
       locations."/" = {
-        root = ./.;
+        root = ./website;
       };
     };
   };


### PR DESCRIPTION
This makes the exmaple a bit more realistic, because you wouldn't
usually want to serve the directory the .nix files are located in.

It also demonstrates how to point to a directory. Beginners might
struggle with trailing slashes and other details of specifying a path.

Finally it makes the example work as-is.