### PR TITLE
default.nix: remove unnecessary nativeBuildInputs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation {
   name = "nix-course";
   src = ./.;
 
-  nativeBuildInputs = with pkgs; [ gnumake pandoc ];
+  nativeBuildInputs = [ pandoc ];
 
   installPhase = ''
     mkdir $out


### PR DESCRIPTION
gnumake is in the default stdenv components. Since we already added all of nixpkgs into the scope in line 1, we don't have to `with pkgs;` again.